### PR TITLE
Fix broken sym mana logic in waggle

### DIFF
--- a/waggle.lic
+++ b/waggle.lic
@@ -741,7 +741,7 @@ check_mana = proc { |spell, num_multicast|
                 else
 					fput 'release' unless checkprep == 'None'
 					echo 'waiting for mana or mana cooldown...'
-					wait_until { spell.affordable?(:multicast => num_multicast) and (mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana) }
+					wait_until { (spell.affordable?(:multicast => num_multicast) and (mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana)) or not symbol_of_mana_cooldown.active?}
 				end
             end
 		elsif use_wracking and sign_of_wracking.known? and not punishment.active? and (spell.mana_cost > 0)


### PR DESCRIPTION
Sym mana currently goes into infinite loop due to using sign of wracking check in the middle of the sym mana logic.
